### PR TITLE
Add Nautobot cookiecutter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Netmiko aims to accomplish both of these operations and to do it across a very b
 
 - [Netmiko Examples](https://github.com/ktbyers/netmiko/blob/develop/EXAMPLES.md)
 
+## Nautobot App Template
+If you are building Nautobot extensions, see [docs/nautobot_app_template.md](docs/nautobot_app_template.md) for
+instructions on generating a project using the official Nautobot cookiecutter template.
+
 <br />
 
 

--- a/docs/nautobot_app_template.md
+++ b/docs/nautobot_app_template.md
@@ -1,0 +1,16 @@
+# Nautobot App Template Guidance
+
+This project follows the Nautobot cookiecutter standards for creating new Nautobot Apps. The official templates provide a Docker Compose development environment and enforce common project structure.
+
+## Generating a New App
+
+Use [Cookiecutter](https://github.com/cookiecutter/cookiecutter) to create a new app skeleton:
+
+```shell
+cookiecutter \
+  --output-dir=./outputs \
+  --directory=nautobot-app \
+  https://github.com/nautobot/cookiecutter-nautobot-app
+```
+
+Refer to the template documentation for the meaning of each prompt. After generation, replace the placeholder logo file and remove all blocks marked `Developer Note - Remove Me!`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ twine = "5.1.1"
 docutils = "0.21.2"
 pysnmp = "6.2.6"
 pdoc3 = "0.11.1"
+coverage = "*"
+pytest-cov = "*"
+ruff = "0.5.5"
 types-paramiko = "3.5.0.20240918"
 types-PyYAML = "6.0.12.20240917"
 setuptools = ">=65.0.0"
@@ -70,3 +73,19 @@ exclude = '''
     | netmiko/_telnetlib
 )/
 '''
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["D", "F", "E", "W", "S", "I"]
+ignore = ["D203", "D212", "D213", "D401", "D407", "D416", "E501"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.coverage.run]
+relative_files = true
+omit = ["*/tests/*"]
+include = ["netmiko/*"]


### PR DESCRIPTION
## Summary
- document Nautobot cookiecutter template usage
- reference the new docs from the README
- configure Ruff and coverage in `pyproject.toml`

## Testing
- `ruff check .` *(fails: many lint errors)*
- `black --check netmiko` *(fails: would reformat files)*
- `pytest -q tests/test_import_netmiko.py --cov=netmiko --cov-report=term-missing`
- `coverage html`


------
https://chatgpt.com/codex/tasks/task_e_686e10586064832681ccf18ce0dcc5d4